### PR TITLE
Add local runner infrastructure and related type annotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+*.log
 _*
 .DS_Store/*
+venv

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,60 @@
+#!/usr/bin/make -f
+
+# Portions of this file contributed by NIST are governed by the
+# following statement:
+#
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to Title 17 Section 105 of the
+# United States Code, this software is not subject to copyright
+# protection within the United States. NIST assumes no responsibility
+# whatsoever for its use by other parties, and makes no guarantees,
+# expressed or implied, about its quality, reliability, or any other
+# characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+SHELL := /bin/bash
+
+all: \
+  check-examples
+	source venv/bin/activate \
+	  && python3 case_viewer/case_viewer.py \
+	    examples/WirelessNetworkConnection.json
+
+.PHONY: \
+  check-examples
+
+.venv.done.log: \
+  pyproject.toml
+	rm -rf venv
+	python3 -m venv venv
+	source venv/bin/activate \
+	  && pip install \
+	    --upgrade \
+	    pip \
+	    poetry
+	source venv/bin/activate \
+	  && poetry install
+	source venv/bin/activate \
+	  && pip install \
+	    case-utils
+	touch $@
+
+check: \
+  check-examples
+
+check-examples: \
+  .venv.done.log
+	$(MAKE) \
+	  --directory examples \
+	  check
+
+clean:
+	@$(MAKE) \
+	  --director examples \
+	  clean
+	@rm -f \
+	  .venv.done.log
+	@rm -rf \
+	  venv

--- a/README.md
+++ b/README.md
@@ -30,3 +30,8 @@ The application relies on Poetry as dependency manager, and all dependencies are
 where:
 
 * JSON_INPUT is the file to be processed.
+
+
+## Licensing
+
+Portions of this repository contributed by NIST are governed by the [NIST Software Licensing Statement](THIRD_PARTY_LICENSES.md#nist-software-licensing-statement).

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ where:
 
 * JSON_INPUT is the file to be processed.
 
+For those with `make` available (e.g. in a POSIX command line environment), `make` will run enough from a fresh `git clone` to set up a demonstration call of the viewer against an [example JSON-LD file](examples/WirelessNetworkConnection.json).
+
 
 ## Licensing
 

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,39 @@
+Portions of this repository contributed by NIST are governed by
+the following license.
+
+
+# NIST Software Licensing Statement
+
+NIST-developed software is provided by NIST as a public service.
+You may use, copy, and distribute copies of the software in any
+medium, provided that you keep intact this entire notice. You may
+improve, modify, and create derivative works of the software or
+any portion of the software, and you may copy and distribute such
+modifications or works. Modified works should carry a notice
+stating that you changed the software and should note the date
+and nature of any such change. Please explicitly acknowledge the
+National Institute of Standards and Technology as the source of
+the software.
+
+NIST-developed software is expressly provided "AS IS." NIST MAKES
+NO WARRANTY OF ANY KIND, EXPRESS, IMPLIED, IN FACT, OR ARISING BY
+OPERATION OF LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
+NON-INFRINGEMENT, AND DATA ACCURACY. NIST NEITHER REPRESENTS NOR
+WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED
+OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE CORRECTED. NIST DOES
+NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE
+SOFTWARE OR THE RESULTS THEREOF, INCLUDING BUT NOT LIMITED TO THE
+CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE
+SOFTWARE.
+
+You are solely responsible for determining the appropriateness of
+using and distributing the software and you assume all risks
+associated with its use, including but not limited to the risks
+and costs of program errors, compliance with applicable laws,
+damage to or loss of data, programs or equipment, and the
+unavailability or interruption of operation. This software is not
+intended to be used in any situation where a failure could cause
+risk of injury or damage to property. The software developed by
+NIST employees is not subject to copyright protection within the
+United States.

--- a/case_viewer/case_viewer.py
+++ b/case_viewer/case_viewer.py
@@ -16,12 +16,27 @@ import json
 import codecs
 import sys
 from collections import deque
+from typing import Optional, Union
 from PyQt5.QtWidgets import *
 from PyQt5.QtGui import *
 #from PyQt5 import QtCore, QtGui, QtWidgets
 from PyQt5 import QtCore
 from PyQt5.QtCore import Qt
 #import logging
+
+# Define Python type for JSON-LD.  This is to help distinguish between
+# general dictionaries and JSON-LD data.
+# Note: This type is slightly more strict than a general JSON type.  In
+# particular, float is intentionally not included, to prevent confusion
+# in type conversions between JSON-LD and Python.
+JSONLD = Union[
+    None,
+    bool,
+    dict[str, "JSONLD"],
+    int,
+    list["JSONLD"],
+    str,
+]
 
 class TableModel(QtCore.QAbstractTableModel):
 	def __init__(self, data):
@@ -155,8 +170,8 @@ class view(QWidget):
 
 
 
-	def buildTableData(self, idObject):
-		self.headers = []
+	def buildTableData(self, idObject: str) -> list:
+		self.headers: list[str] = []
 		tData = self.buildDataChatMessages(idObject)
 		if len(tData) == 0:
 			tData = self.buildDataPhoneCalls(idObject)
@@ -289,7 +304,7 @@ class view(QWidget):
 		return tData
 
 
-	def buildDataWirelessNet(self, idObject):
+	def buildDataWirelessNet(self, idObject: str) -> list[list[str]]:
 		tData = []
 		if idObject == ':WirelessNet':
 			self.headers = ["SSID", "BSID"]
@@ -906,7 +921,7 @@ class view(QWidget):
 		return html_text
 
 
-	def gather_all_wireless_nets(self):
+	def gather_all_wireless_nets(self) -> str:
 		html_text="<h2>Wireless Network connections</h2><br/>"
 		for item in wireless_net:
 			html_text = html_text + \
@@ -1370,7 +1385,8 @@ def processSocialMediaActivities(jsonObj, facet):
 		print (e)
 
 
-def processWirelessNetwork(jsonObj, facet):
+def processWirelessNetwork(jsonObj: dict[str, JSONLD], facet: dict[str, JSONLD]) -> None:
+	assert isinstance(jsonObj["@id"], str), "Anonymous object found in CASE JSON-LD data."
 	wId = jsonObj["@id"]
 	wSsid = get_attribute(facet, "uco-observable:ssid", '')
 	wBssid = get_attribute(facet, "uco-observable:baseStation", '')
@@ -1840,7 +1856,7 @@ if __name__ == '__main__':
 	searched_items = []
 	social_media_activities = []
 	events = []
-	wireless_net = []
+	wireless_net: list[dict[str, str]] = []
 	relationAttachmentsTo = []
 	relationMappedBy = []
 	relationConnectedTo = []

--- a/case_viewer/case_viewer.py
+++ b/case_viewer/case_viewer.py
@@ -1,3 +1,17 @@
+# Portions of this file contributed by NIST are governed by the
+# following statement:
+#
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to Title 17 Section 105 of the
+# United States Code, this software is not subject to copyright
+# protection within the United States. NIST assumes no responsibility
+# whatsoever for its use by other parties, and makes no guarantees,
+# expressed or implied, about its quality, reliability, or any other
+# characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
 import json
 import codecs
 import sys

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,0 +1,37 @@
+#!/usr/bin/make -f
+
+# Portions of this file contributed by NIST are governed by the
+# following statement:
+#
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to Title 17 Section 105 of the
+# United States Code, this software is not subject to copyright
+# protection within the United States. NIST assumes no responsibility
+# whatsoever for its use by other parties, and makes no guarantees,
+# expressed or implied, about its quality, reliability, or any other
+# characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+SHELL := /bin/bash
+
+top_srcdir := ..
+
+all: \
+  .WirelessNetworkConnection.json.validates.log
+
+.%.json.validates.log: \
+  %.json \
+  $(top_srcdir)/.venv.done.log
+	source $(top_srcdir)/venv/bin/activate \
+	  && case_validate \
+	    $<
+	touch $@
+
+check: \
+  all
+
+clean:
+	@rm -f \
+	  .*.validates.log

--- a/examples/WirelessNetworkConnection.json
+++ b/examples/WirelessNetworkConnection.json
@@ -1,0 +1,49 @@
+{
+    "@context": {
+        "case-investigation": "https://ontology.caseontology.org/case/investigation/",
+        "kb": "http://example.org/kb/",
+        "uco-core": "https://ontology.unifiedcyberontology.org/uco/core/",
+        "uco-observable": "https://ontology.unifiedcyberontology.org/uco/observable/",
+        "xsd": "http://www.w3.org/2001/XMLSchema#"
+    },
+    "@graph": [
+        {
+            "@id": "kb:WirelessNetworkConnection-3b5b984f-94b8-4ba4-9e8c-a22c7fbe099c",
+            "@type": "uco-observable:WirelessNetworkConnection",
+            "case-investigation:wasDerivedFrom": [],
+            "uco-core:createdBy": null,
+            "uco-core:description": [],
+            "uco-core:externalReference": [],
+            "uco-core:hasFacet": [
+                {
+                    "@id": "kb:NetworkConnectionFacet-56caca86-f700-4edb-83bf-757729c1ad14",
+                    "@type": "uco-observable:NetworkConnectionFacet",
+                    "uco-observable:destinationPort": null,
+                    "uco-observable:dst": [],
+                    "uco-observable:endTime": null,
+                    "uco-observable:isActive": null,
+                    "uco-observable:protocols": null,
+                    "uco-observable:sourcePort": null,
+                    "uco-observable:src": [],
+                    "uco-observable:startTime": null
+                },
+                {
+                    "@id": "kb:WirelessNetworkConnectionFacet-db797ecd-32b0-429d-ae4a-47c2f91d43d4",
+                    "@type": "uco-observable:WirelessNetworkConnectionFacet",
+                    "uco-observable:baseStation": "EXAMPLE",
+                    "uco-observable:password": null,
+                    "uco-observable:ssid": null,
+                    "uco-observable:wirelessNetworkSecurityMode": null
+                }
+            ],
+            "uco-core:modifiedTime": [],
+            "uco-core:name": null,
+            "uco-core:objectCreatedTime": null,
+            "uco-core:objectMarking": [],
+            "uco-core:specVersion": null,
+            "uco-core:tag": [],
+            "uco-observable:hasChanged": null,
+            "uco-observable:state": null
+        }
+    ]
+}


### PR DESCRIPTION
This PR adds:

* A NIST license for files contributed as 3rd-party.
* A `Makefile`, so `make` called with no arguments sets up the scaffolding necessary to perform an example run of `case_viewer.py`.
* An example graph containing a `WirelessNetworkConnection` object.  The graph file was primed by copying [this JSON-LD stub](https://github.com/casework/CASE-Mapping-Template-Stubs/blob/c39997cecd023c106720a80d9496382e065d9c51/templates/uco-observable/WirelessNetworkConnection.json) from the [CASE-Mapping-Template-Stubs](https://github.com/casework/CASE-Mapping-Template-Stubs) repository.
* Sufficient `make` scripting to confirm the example file passes CASE validation before being passed to `case_viewer.py`.
* Some Python type annotations along the code path to rendering the `WirelessNetworkConnection`.


## Disclaimer

Participation by NIST in the creation of the documentation of mentioned software is not intended to imply a recommendation or endorsement by the National Institute of Standards and Technology, nor is it intended to imply that any specific software is necessarily the best available for the purpose.