### PR TITLE
Move some global resources to library with more extensive tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,4 +51,6 @@ jobs:
     - name: Run tests
       run: |
         poetry install
+        poetry run mypy --strict case_viewer/lib.py
+        poetry run pytest --doctest-modules case_viewer/lib.py
         poetry run mypy case_viewer/case_viewer.py

--- a/Makefile
+++ b/Makefile
@@ -27,14 +27,28 @@ all: \
 
 .mypy.done.log: \
   .venv.done.log \
-  case_viewer/case_viewer.py
+  case_viewer/case_viewer.py \
+  case_viewer/lib.py
+	source venv/bin/activate \
+	  && poetry run mypy \
+	    --strict \
+	    case_viewer/lib.py
 	source venv/bin/activate \
 	  && poetry run mypy \
 	    case_viewer/case_viewer.py
 	touch $@
 
+.pytest.done.log: \
+  .mypy.done.log
+	source venv/bin/activate \
+	  && poetry run pytest \
+	    --doctest-modules \
+	    case_viewer/lib.py
+	touch $@
+
 .venv.done.log: \
   pyproject.toml
+	rm -f poetry.lock
 	rm -rf venv
 	python3 -m venv venv
 	source venv/bin/activate \
@@ -50,7 +64,7 @@ all: \
 	touch $@
 
 check: \
-  .mypy.done.log \
+  .pytest.done.log \
   check-examples
 
 check-examples: \

--- a/case_viewer/case_viewer.py
+++ b/case_viewer/case_viewer.py
@@ -22,19 +22,7 @@ from PyQt5.QtGui import *
 from PyQt5 import QtCore
 #import logging
 
-# Define Python type for JSON-LD.  This is to help distinguish between
-# general dictionaries and JSON-LD data.
-# Note: This type is slightly more strict than a general JSON type.  In
-# particular, float is intentionally not included, to prevent confusion
-# in type conversions between JSON-LD and Python.
-JSONLD = Union[
-    None,
-    bool,
-    dict[str, "JSONLD"],
-    int,
-    list["JSONLD"],
-    str,
-]
+from .lib import JSONLD, get_attribute, get_optional_integer_attribute, get_optional_string_attribute
 
 class TableModel(QtCore.QAbstractTableModel):
 	def __init__(self, data):
@@ -929,16 +917,6 @@ class view(QWidget):
 
 
 ### global funtions
-def get_attribute(data: dict[str, JSONLD], property: str, default_value: JSONLD) -> JSONLD:
-	return data.get(property) or default_value
-
-
-def get_optional_string_attribute(data: dict[str, JSONLD], property: str, default_value: str) -> str:
-	return_value: JSONLD = get_attribute(data, property, default_value)
-	assert isinstance(return_value, str)
-	return return_value
-
-
 def process_id_messages():
 	for m in chatMessages:
 		if m["uco-observable:application-id"]:
@@ -1165,7 +1143,8 @@ def processThread(uuid_object=None, facet=None):
 	thread_participants = list()
 	for p in facet["uco-observable:participant"]:
 		thread_participants.append(p["@id"])
-	thread_len = facet["uco-observable:messageThread"]["co:size"]["@value"]
+	thread = facet["uco-observable:messageThread"]
+	thread_len = get_optional_integer_attribute(thread, "co:size", "-")
 	thread_messages = list()
 	thread_elements = facet["uco-observable:messageThread"]["co:element"]
 	if isinstance(thread_elements, dict):
@@ -1515,9 +1494,7 @@ def processCall(uuid_object=None, facet=None):
 	callStartTime = facet.get("uco-observable:startTime", "-")
 	if callStartTime != "-":
 		callStartTime = facet["uco-observable:startTime"]["@value"]
-	callDuration = get_attribute(facet, "uco-observable:duration", "-")
-	if callDuration != "-":
-		callDuration = facet["uco-observable:duration"]["@value"]
+	callDuration = get_optional_integer_attribute(facet, "uco-observable:duration", "-")
 	#callStatus = get_attribute(facet, "uco-observable:allocationStatus", "-")
 	try:
 		phoneCalls.append(
@@ -1603,9 +1580,7 @@ def processFile(jsonObj, facet):
 	fileTag = get_attribute(facet, "uco-observable:mimeType", "-")
 	fileName = get_attribute(facet, "uco-observable:fileName", "-")
 	filePath = get_attribute(facet, "uco-observable:filePath", "-")
-	fileSize = get_attribute(facet, "uco-observable:sizeInBytes", "0")
-	if fileSize != "0":
-		fileSize = facet["uco-observable:sizeInBytes"]["@value"]
+	fileSize = get_optional_integer_attribute(facet, "uco-observable:sizeInBytes", "-")
 	tagProcessed = False;
 	try:
 		fileTagNorm = fileTag.lower()

--- a/case_viewer/lib.py
+++ b/case_viewer/lib.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+
+# Portions of this file contributed by NIST are governed by the
+# following statement:
+#
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to Title 17 Section 105 of the
+# United States Code, this software is not subject to copyright
+# protection within the United States. NIST assumes no responsibility
+# whatsoever for its use by other parties, and makes no guarantees,
+# expressed or implied, about its quality, reliability, or any other
+# characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+from typing import Union
+
+# Define Python type for JSON-LD.  This is to help distinguish between
+# general dictionaries and JSON-LD data.
+# Note: This type is slightly more strict than a general JSON type.  In
+# particular, float is intentionally not included, to prevent confusion
+# in type conversions between JSON-LD and Python.
+JSONLD = Union[
+    None,
+    bool,
+    dict[str, "JSONLD"],
+    int,
+    list["JSONLD"],
+    str,
+]
+
+
+def get_attribute(data: dict[str, JSONLD], property: str, default_value: JSONLD) -> JSONLD:
+	"""
+	This method gets the value of a property in the ``data`` object. Any JSON-LD type-variant aside from None is returned.  If the property is None, or not assigned in the ``data`` object, the thing passed as ``default_value`` is instead returned.
+
+	>>> example0 = {"ex:foo": None}
+	>>> get_attribute(example0, "ex:foo", "-")
+	'-'
+	>>> example1 = {"ex:foo": 0}
+	>>> get_attribute(example1, "ex:foo", "-")
+	0
+	>>> example2 = {"ex:foo": False}
+	>>> get_attribute(example2, "ex:foo", "-")
+	False
+	>>> example3 = {"ex:foo": [1, "a", None]}
+	>>> get_attribute(example3, "ex:foo", "-")
+	[1, 'a', None]
+	>>> get_attribute(example3, "ex:bar", "-")
+	'-'
+	"""
+	if property not in data:
+		return default_value
+	if data[property] is None:
+		return default_value
+	return data[property]
+
+
+def get_optional_integer_attribute(data: dict[str, JSONLD], property: str, default_value: str) -> str:
+	"""
+	>>> example0 = {"ex:foo": 0}
+	>>> get_optional_integer_attribute(example0, "ex:foo", "-")
+	'0'
+	>>> get_optional_integer_attribute(example0, "ex:bar", "-")
+	'-'
+	>>> example1 = {"ex:foo": 1}
+	>>> get_optional_integer_attribute(example1, "ex:foo", "-")
+	'1'
+	>>> example2 = {"ex:foo": -1}
+	>>> get_optional_integer_attribute(example2, "ex:foo", "-")
+	'-1'
+	>>> example3 = {"ex:foo": {"@type": "xsd:negativeInteger", "@value": "-1"}}
+	>>> get_optional_integer_attribute(example3, "ex:foo", "-")
+	'-1'
+	>>> example4 = {"ex:foo": [1, 2, 3]}
+	>>> get_optional_integer_attribute(example4, "ex:foo", "-")
+	Traceback (most recent call last):
+	...
+	TypeError: Unexpected type for property 'ex:foo': <class 'list'>.
+	"""
+	return_value: JSONLD = get_attribute(data, property, default_value)
+	if return_value is None:
+		return default_value
+	elif isinstance(return_value, dict):
+		if "@value" not in return_value:
+			raise ValueError("JSON object is not JSON-LD typed-literal dictionary: %r." % return_value)
+		assert isinstance(return_value["@value"], str)
+		if return_value["@value"][0] == "-":
+			check_value = return_value["@value"][1:]
+		else:
+			check_value = return_value["@value"]
+		if not check_value.isnumeric():
+			raise ValueError("Typed-literal value is not numeric: %r." % return_value["@value"])
+		return return_value["@value"]
+	elif isinstance(return_value, int):
+		return str(return_value)
+	elif isinstance(return_value, str):
+		return return_value
+	raise TypeError("Unexpected type for property %r: %r." % (property, type(return_value)))
+
+
+def get_optional_string_attribute(data: dict[str, JSONLD], property: str, default_value: str) -> str:
+	return_value: JSONLD = get_attribute(data, property, default_value)
+	if isinstance(return_value, str):
+		return return_value
+	raise TypeError("Unexpected type for property %r: %r." % (property, type(return_value)))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ argparse = "^1.4.0"
 
 [tool.poetry.dev-dependencies]
 mypy = "^1"
+pytest = "^8"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
This PR started from encountering a code-branch that was handling nontrivial integer retrieval and realizing there was a piece of logic worth encapsulating.  The end result is a library module is now added with more stringent testing in place, with the benefits of doctests, further type review, and a bugfix in the global property retrieval function.


## Disclaimer

Participation by NIST in the creation of the documentation of mentioned software is not intended to imply a recommendation or endorsement by the National Institute of Standards and Technology, nor is it intended to imply that any specific software is necessarily the best available for the purpose.


## Encapsulated logic

* Retrieval of integer values is now handled with `get_optional_integer_attribute`, which should be used for integer-valued properties of [0..1] cardinality.
   - `get_optional_integer_attribute` handles retrieving integers stored either as primitive JSON integers or the JSON-LD typed-literal dictionary form (`{"@type": ..., "@value": ...}`).


## Further infrastructure added

* `case_viewer/lib.py`, which now house `get_attribute` and its wrappers, and the `JSONLD` type.  This file is reviewed with `mypy --strict` in CI and local `make check`.
* `pytest` for running documentation tests.  This is now run in CI and local `make check`.


## Bug fixed

* Trying to use `get_attribute` to retrieve a data value that turned out to be "False-y", like `0`, was causing the default string value to be returned instead.  A doctest now demonstrates the desired behavior is met.
   - Clarification: A `None` in the data will cause `default_value` to be returned.


## Behavior changes

* `get_optional_string_attribute` now raises a `TypeError` rather than an `AssertionError` on encountering a non-string return value.
