### PR TITLE
Address Poetry section deprecation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ json5 = "^0.9.25"
 pyqt5 = "^5.15.10"
 argparse = "^1.4.0"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 mypy = "^1"
 pytest = "^8"
 


### PR DESCRIPTION
This is a response to this warning raised during the build:

> The "poetry.dev-dependencies" section is deprecated and will be removed in a future version. Use "poetry.group.dev.dependencies" instead.

I'll be merging this once CI passes.