### PR TITLE
Relink and bump `case-utils`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
 
     - name: Run tests
       run: |
-        poetry install
+        poetry install --with dev
         poetry run mypy --strict case_viewer/lib.py
         poetry run pytest --doctest-modules case_viewer/lib.py
         poetry run mypy case_viewer/case_viewer.py

--- a/Makefile
+++ b/Makefile
@@ -69,10 +69,8 @@ all: \
 	    pip \
 	    poetry
 	source venv/bin/activate \
-	  && poetry install
-	source venv/bin/activate \
-	  && pip install \
-	    case-utils
+	  && poetry install \
+	    --with dev
 	touch $@
 
 check: \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## A GUI application based on QT5 to visualise JSON-LD files complied with the UCO/CASE ontology.
 
-The JSON-LD files must be complied with the UCO/CASE version 1,3 but they are also based on the *drafting* namespace, aimed to represent artifact not included in the ontology yet. The application processes the following Artifacts:
+The JSON-LD files must be complied with the UCO/CASE version 1.4.0 but they are also based on the *drafting* namespace, aimed to represent artifact not included in the ontology yet. The application processes the following Artifacts:
 
 * ACCOUNT
 * CALL

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ argparse = "^1.4.0"
 optional = true
 
 [tool.poetry.group.dev.dependencies]
-case-utils = "^0.16"
+case-utils = "^0.17"
 mypy = "^1"
 pytest = "^8"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,11 @@ json5 = "^0.9.25"
 pyqt5 = "^5.15.10"
 argparse = "^1.4.0"
 
+[tool.poetry.group.dev]
+optional = true
+
 [tool.poetry.group.dev.dependencies]
+case-utils = "^0.16"
 mypy = "^1"
 pytest = "^8"
 


### PR DESCRIPTION
This PR started out as a bump to `case-utils`, but on review of how `case-utils` was linked in the build system, the Poetry TOML gets an update to recognize `case-utils` as a development-only dependency.